### PR TITLE
Update method signature for translate_exception 

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -192,7 +192,7 @@ module ActiveRecord
 
       # Translate an exception from the native DBMS to something usable by
       # ActiveRecord.
-      def translate_exception(exception, message)
+      def translate_exception(exception, message:, sql:, binds:)
         error_number = exception.message[/^\d+/].to_i
 
         if error_number == ERR_DUPLICATE_KEY_VALUE

--- a/odbc_adapter.gemspec
+++ b/odbc_adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 5.2', '< 8'
+  spec.add_dependency 'activerecord', '>= 6.0', '< 8'
   spec.add_dependency 'ruby-odbc', '~> 0.9'
 
   spec.add_development_dependency 'bundler',   '>= 1.14'


### PR DESCRIPTION
This changed in Rails 6, which is all we care to support. Make this explicit by updating the version constraint too.

This signature mismatch causes timeouts to misreport as ArgumentError