### PR TITLE
Rails 7 fixes

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -104,6 +104,7 @@ module ActiveRecord
         configure_time_options(connection)
         super(connection, logger, config)
         @database_metadata = database_metadata
+        @raw_connection = connection
       end
 
       # Returns the human-readable name of the adapter.
@@ -117,26 +118,31 @@ module ActiveRecord
         true
       end
 
+       # ODBC adapter does not support the returning clause
+      def supports_insert_returning?
+        false
+      end
+
       # CONNECTION MANAGEMENT ====================================
 
       # Checks whether the connection to the database is still active. This
       # includes checking whether the database is actually capable of
       # responding, i.e. whether the connection isn't stale.
       def active?
-        @connection.connected?
+        @raw_connection.connected?
       end
 
       # Disconnects from the database if already connected, and establishes a
       # new connection with the database.
       def reconnect!
         disconnect!
-        @connection =
+        @raw_connection =
           if @config[:driver]
             ODBC::Database.new.drvconnect(@config[:driver])
           else
             ODBC.connect(@config[:dsn], @config[:username], @config[:password])
           end
-        configure_time_options(@connection)
+        configure_time_options(@raw_connection)
         super
       end
       alias reset! reconnect!
@@ -144,16 +150,24 @@ module ActiveRecord
       # Disconnects from the database if already connected. Otherwise, this
       # method does nothing.
       def disconnect!
-        @connection.disconnect if @connection.connected?
+        @raw_connection.disconnect if @raw_connection.connected?
       end
 
       # Build a new column object from the given options. Effectively the same
       # as super except that it also passes in the native type.
       # rubocop:disable Metrics/ParameterLists
-      def new_column(name, default, sql_type_metadata, null, table_name, default_function = nil, collation = nil, native_type = nil)
-        ::ODBCAdapter::Column.new(name, default, sql_type_metadata, null, table_name, default_function, collation, native_type)
+      def new_column(name, default, sql_type_metadata, null, default_function = nil, collation: nil, native_type: nil)
+        ::ODBCAdapter::Column.new(
+          name, 
+          default, 
+          sql_type_metadata, 
+          null, 
+          default_function, 
+          collation: collation, 
+          native_type: native_type, 
+        )
       end
-      # rubocop:enable Metrics/ParameterLists
+      
 
       protected
 

--- a/lib/odbc_adapter/column.rb
+++ b/lib/odbc_adapter/column.rb
@@ -5,8 +5,17 @@ module ODBCAdapter
     # Add the native_type accessor to allow the native DBMS to report back what
     # it uses to represent the column internally.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(name, default, sql_type_metadata = nil, null = true, table_name = nil, native_type = nil, default_function = nil, collation = nil)
-      super(name, default, sql_type_metadata, null, table_name, default_function, collation)
+
+    def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil, collation: nil, comment: nil, native_type: nil)
+      super(
+        name, 
+        default, 
+        sql_type_metadata, 
+        null, 
+        default_function, 
+        collation: collation,
+        comment: comment.presence,
+      )
       @native_type = native_type
     end
     # rubocop:enable Metrics/ParameterLists

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -10,9 +10,9 @@ module ODBCAdapter
     def execute(sql, name = nil, binds = [])
       log(sql, name) do
         if prepared_statements
-          @connection.do(sql, *prepared_binds(binds))
+          @raw_connection.do(sql, *prepared_binds(binds))
         else
-          @connection.do(sql)
+          @raw_connection.do(sql)
         end
       end
     end
@@ -20,13 +20,13 @@ module ODBCAdapter
     # Executes +sql+ statement in the context of this connection using
     # +binds+ as the bind substitutes. +name+ is logged along with
     # the executed +sql+ statement.
-    def exec_query(sql, name = 'SQL', binds = [], prepare: false) # rubocop:disable Lint/UnusedMethodArgument
+    def internal_exec_query(sql, name = 'SQL', binds = [], prepare: false) # rubocop:disable Lint/UnusedMethodArgument
       log(sql, name) do
         stmt =
           if prepared_statements
-            @connection.run(sql, *prepared_binds(binds))
+            @raw_connection.run(sql, *prepared_binds(binds))
           else
-            @connection.run(sql)
+            @raw_connection.run(sql)
           end
 
         columns = stmt.columns
@@ -49,20 +49,20 @@ module ODBCAdapter
 
     # Begins the transaction (and turns off auto-committing).
     def begin_db_transaction
-      @connection.autocommit = false
+      @raw_connection.autocommit = false
     end
 
     # Commits the transaction (and turns on auto-committing).
     def commit_db_transaction
-      @connection.commit
-      @connection.autocommit = true
+      @raw_connection.commit
+      @raw_connection.autocommit = true
     end
 
     # Rolls back the transaction (and turns on auto-committing). Must be
     # done if the transaction block raises an exception or returns false.
     def exec_rollback_db_transaction
-      @connection.rollback
-      @connection.autocommit = true
+      @raw_connection.rollback
+      @raw_connection.autocommit = true
     end
 
     # Returns the default sequence name for a table.

--- a/lib/odbc_adapter/quoting.rb
+++ b/lib/odbc_adapter/quoting.rb
@@ -28,7 +28,7 @@ module ODBCAdapter
     # sequence, but not all ODBC drivers support them.
     def quoted_date(value)
       if value.acts_like?(:time)
-        zone_conversion_method = ActiveRecord::Base.default_timezone == :utc ? :getutc : :getlocal
+        zone_conversion_method = ActiveRecord.default_timezone == :utc ? :getutc : :getlocal
 
         if value.respond_to?(zone_conversion_method)
           value = value.send(zone_conversion_method)

--- a/lib/odbc_adapter/schema_statements.rb
+++ b/lib/odbc_adapter/schema_statements.rb
@@ -10,7 +10,7 @@ module ODBCAdapter
     # Returns an array of table names, for database tables visible on the
     # current connection.
     def tables(_name = nil)
-      stmt   = @connection.tables
+      stmt   = @raw_connection.tables
       result = stmt.fetch_all || []
       stmt.drop
 
@@ -28,7 +28,7 @@ module ODBCAdapter
 
     # Returns an array of indexes for the given table.
     def indexes(table_name, _name = nil)
-      stmt   = @connection.indexes(native_case(table_name.to_s))
+      stmt   = @raw_connection.indexes(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
 
@@ -59,7 +59,7 @@ module ODBCAdapter
     # Returns an array of Column objects for the table specified by
     # +table_name+.
     def columns(table_name, _name = nil)
-      stmt   = @connection.columns(native_case(table_name.to_s))
+      stmt   = @raw_connection.columns(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop
 
@@ -89,14 +89,14 @@ module ODBCAdapter
 
     # Returns just a table's primary key
     def primary_key(table_name)
-      stmt   = @connection.primary_keys(native_case(table_name.to_s))
+      stmt   = @raw_connection.primary_keys(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
       result[0] && result[0][3]
     end
 
     def foreign_keys(table_name)
-      stmt   = @connection.foreign_keys(native_case(table_name.to_s))
+      stmt   = @raw_connection.foreign_keys(native_case(table_name.to_s))
       result = stmt.fetch_all || []
       stmt.drop unless stmt.nil?
 

--- a/odbc_adapter.gemspec
+++ b/odbc_adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 6.0', '< 8'
+  spec.add_dependency 'activerecord', '>= 7.1.2', '< 8'
   spec.add_dependency 'ruby-odbc', '>= 0.9', '< 2'
 
   spec.add_development_dependency 'bundler',   '>= 1.14'


### PR DESCRIPTION
Add Rails 7 / Ruby 3 support for the Mitchells fork of the `odbc_adapter` gem.